### PR TITLE
Add Dockerfile and docker-compose for Django app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["gunicorn", "thesis.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    command: gunicorn thesis.wsgi:application --bind 0.0.0.0:8000
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+      - PYTHONUNBUFFERED=1


### PR DESCRIPTION
### Motivation
- Provide a reproducible container image for running the Django application with a production-ready WSGI server.
- Enable convenient local development and deployment via `docker-compose` with mapped ports and a bind mount for source code changes.

### Description
- Add `Dockerfile` that uses `python:3.10-slim`, sets `PYTHONDONTWRITEBYTECODE` and `PYTHONUNBUFFERED`, installs `build-essential`, installs Python dependencies from `requirements.txt`, copies the project into `/app`, exposes port `8000`, and starts the app with `gunicorn thesis.wsgi:application`.
- Add `docker-compose.yaml` with a `web` service that builds from the repository, runs `gunicorn thesis.wsgi:application --bind 0.0.0.0:8000`, maps host port `8000` to container port `8000`, mounts the project directory into the container for development, and sets the Python runtime environment variables.
- Both files were added to the repository and committed.

### Testing
- Verified file contents using `nl -ba Dockerfile` and `nl -ba docker-compose.yaml` which displayed the expected content and returned successfully.
- Confirmed repository changes were staged and committed with `git add` and `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f42764988327aa06f24c32891f9b)