### PR TITLE
Refactor app flow to use a single HTML page for authenticated screens

### DIFF
--- a/covidtracker/views.py
+++ b/covidtracker/views.py
@@ -1,78 +1,142 @@
-from django.shortcuts import render,redirect
+from django.shortcuts import render, redirect
 from django.contrib.auth.models import auth
 from django.contrib.auth.decorators import login_required
 import covidtracker.models
 import datetime
 
+
 def home(request):
-    user=request.user
-    if user.is_authenticated==True:
-        lecture=covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
-        return render(request,'index.html',{"user":user.username,"lecture":lecture})
-    else:
-        return render(request,'login.html')
+    user = request.user
+    if user.is_authenticated is True:
+        lecture = covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
+        position = covidtracker.models.Position.objects.filter(user=user)
+        return render(
+            request,
+            'index.html',
+            {
+                'user': user.username,
+                'lecture': lecture,
+                'position': position,
+                'view': 'home',
+            },
+        )
+    return render(request, 'login.html')
+
 
 def login(request):
-    if(request.method=='POST'):
-       username=request.POST['username']
-       password=request.POST['password']
-       user=auth.authenticate(username=username,password=password)
-       if(user is not None):
-           auth.login(request,user)
-           return redirect('/')
-       else:
-           return render(request,'login.html',{'result':"Wrong Password or Username!"})
-    else:
-        user=request.user
-        if user.is_authenticated==True:
-           return redirect('/')
-        else:
-           return render(request,'login.html')
+    if request.method == 'POST':
+        username = request.POST['username']
+        password = request.POST['password']
+        user = auth.authenticate(username=username, password=password)
+        if user is not None:
+            auth.login(request, user)
+            return redirect('/')
+        return render(request, 'login.html', {'result': 'Wrong Password or Username!'})
+
+    user = request.user
+    if user.is_authenticated is True:
+        return redirect('/')
+    return render(request, 'login.html')
+
 
 @login_required
 def logout(request):
     auth.logout(request)
     return redirect('/')
 
+
 @login_required
 def show(request):
-    user=request.user
-    position=covidtracker.models.Position.objects.filter(user=user)
-    return render(request,'show.html',{'position':position})
+    user = request.user
+    lecture = covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
+    position = covidtracker.models.Position.objects.filter(user=user)
+    return render(
+        request,
+        'index.html',
+        {
+            'user': user.username,
+            'lecture': lecture,
+            'position': position,
+            'view': 'show',
+        },
+    )
 
-@login_required    
-def lecture(request,id):
-    lecture=covidtracker.models.Lecture.objects.filter(id=id)
-    return render(request,'position.html',{'lecture':lecture})
 
 @login_required
-def add(request,id):
-    lecture=covidtracker.models.Lecture.objects.get(id=id)
-    if(request.method=='POST'):
-        positionNumber=request.POST['positionNumber']
-        user=request.user
-        if covidtracker.models.Position.objects.filter(user=user,lecture=lecture).exists():
-            lecture=covidtracker.models.Lecture.objects.filter(id=id)
-            return render(request,'position.html',{"user":user.username,"lecture":lecture,'result':'Εχετε ήδη δηλώσει την θέση σας'})
-        elif covidtracker.models.Position.objects.filter(lecture=lecture,positionNumber=positionNumber).exists():
-            lecture=covidtracker.models.Lecture.objects.filter(id=id)
-            return render(request,'position.html',{"user":user.username,"lecture":lecture,'result':'Η θέση είναι πιασμένη'})    
-        elif covidtracker.models.Position.objects.filter(lecture=lecture,positionNumber=positionNumber).exists()==False:  
-            covidtracker.models.Position(user=user,lecture=lecture,positionNumber=positionNumber).save()
-            return redirect('/') 
-    else:
+def lecture(request, id):
+    user = request.user
+    lecture = covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
+    selected_lecture = covidtracker.models.Lecture.objects.filter(id=id)
+    position = covidtracker.models.Position.objects.filter(user=user)
+    return render(
+        request,
+        'index.html',
+        {
+            'user': user.username,
+            'lecture': lecture,
+            'selected_lecture': selected_lecture,
+            'position': position,
+            'view': 'lecture',
+        },
+    )
+
+
+@login_required
+def add(request, id):
+    lecture = covidtracker.models.Lecture.objects.get(id=id)
+    if request.method == 'POST':
+        positionNumber = request.POST['positionNumber']
+        user = request.user
+        if covidtracker.models.Position.objects.filter(user=user, lecture=lecture).exists():
+            return _render_lecture_with_message(request, user, id, 'Εχετε ήδη δηλώσει την θέση σας')
+        if covidtracker.models.Position.objects.filter(lecture=lecture, positionNumber=positionNumber).exists():
+            return _render_lecture_with_message(request, user, id, 'Η θέση είναι πιασμένη')
+
+        covidtracker.models.Position(user=user, lecture=lecture, positionNumber=positionNumber).save()
         return redirect('/')
+    return redirect('/')
+
 
 @login_required
 def covid(request):
-    return render(request,'covid.html')
+    user = request.user
+    lecture = covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
+    position = covidtracker.models.Position.objects.filter(user=user)
+    return render(
+        request,
+        'index.html',
+        {
+            'user': user.username,
+            'lecture': lecture,
+            'position': position,
+            'view': 'covid',
+        },
+    )
+
 
 @login_required
 def covidAdd(request):
-    user=request.user
-    if request.method=='POST':
-        date=request.POST['date']
-        covidtracker.models.CovidCase(user=user,date=date).save()
+    user = request.user
+    if request.method == 'POST':
+        date = request.POST['date']
+        covidtracker.models.CovidCase(user=user, date=date).save()
         return redirect('/')
-    else:
-        return redirect('/') 
+    return redirect('/')
+
+
+def _render_lecture_with_message(request, user, lecture_id, result):
+    lecture = covidtracker.models.Lecture.objects.filter(date=datetime.date.today())
+    selected_lecture = covidtracker.models.Lecture.objects.filter(id=lecture_id)
+    position = covidtracker.models.Position.objects.filter(user=user)
+    return render(
+        request,
+        'index.html',
+        {
+            'user': user.username,
+            'lecture': lecture,
+            'selected_lecture': selected_lecture,
+            'position': position,
+            'result': result,
+            'view': 'lecture',
+        },
+    )

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,8 +8,8 @@
     <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300i,400,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/css/bootstrap.min.css">
-    <title>Hua Covid-19 Tracker | Home</title>
-    <link rel="stylesheet" type="text/css" href="{% static 'css/index.css' %}"> 
+    <title>Hua Covid-19 Tracker</title>
+    <link rel="stylesheet" type="text/css" href="{% static 'css/index.css' %}">
 </head>
 <body>
   <section class="navigation">
@@ -19,57 +19,116 @@
       </div>
       <nav>
         <ul class="nav-list">
-          <li>
-            <a style="color: white;">{{user}}</a>
-          </li>
-          <li>
-            <a href="/covid">Δήλωση Κρούσματος Covid-19</a>
-          </li>
-          <li>
-            <a href="/show">Show All Data</a>
-          </li>
-          <li>
-            <a href="/logout">Log out</a>
-          </li>
+          <li><a style="color: white;">{{user}}</a></li>
+          <li><a href="/covid">Δήλωση Κρούσματος Covid-19</a></li>
+          <li><a href="/show">Show All Data</a></li>
+          <li><a href="/logout">Log out</a></li>
         </ul>
       </nav>
     </div>
   </section>
+
+  {% if view == 'covid' %}
+  <br><br>
+  <h2 style="text-align: center;">Δήλωση Κρούσματος</h2><br>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-3"></div>
+      <div class="col-md-6 p-0 pt-3">
+        <form class="login-form" action="/covidAdd" method="POST">
+           {% csrf_token %}
+           <div class="mb-3 bg-color">
+           <label>Ημερομηνία διάγνωσης</label>
+           <input type="date" name="date" class="form-control" required>
+          </div>
+          <input type="submit" class="btn btn-custom btn-lg btn-block mt-3" value="Βεβαίωση Κρούσματος">
+          <div class="text-center pt-3 pb-3">
+            <h4>{{result}}</h4>
+          </div>
+        </form>
+      </div>
+      <div class="col-md-3"></div>
+    </div>
+  </div>
+
+  {% elif view == 'show' %}
+  <table style="width: 100%; margin: 40px;">
+    <thead>
+       <tr>
+         <th>Θέση</th><th>Μάθημα</th><th>Καθηγητής</th><th>Τύπος μαθήματος</th><th>Ημερομηνία</th><th>Ωρα Εναρξης</th><th>Ωρα λήξης</th><th>Αίθουσα</th>
+       </tr>
+    </thead>
+    <tbody>
+      {% for i in position %}
+       <tr class="even:bg-gray-50">
+        <td class="py-4 px-6">{{i.positionNumber}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.lesson}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.professor}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.lessonType}}</td>
+         <td class="py-4 px-6">{{i.lecture.date}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.startingHour}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.endingHour}}</td>
+         <td class="py-4 px-6">{{i.lecture.course.amphitheater.name}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {% elif view == 'lecture' %}
+  <br><br>
+  <h2 style="text-align: center;">Στοιχεία Διάλεξης</h2>
+  <table style="width: 100%; margin: 40px;">
+    <thead>
+       <tr>
+         <th>Μάθημα</th><th>Καθηγητής</th><th>Τύπος μαθήματος</th><th>Ημερομηνία</th><th>Ωρα έναρξης</th><th>Ωρα λήξης</th><th>Αίθουσα</th><th>Χώρητικότητα Αίθουσας</th>
+       </tr>
+    </thead>
+    <tbody>
+      {% for i in selected_lecture %}
+       <tr class="even:bg-gray-50">
+         <td class="py-4 px-6">{{i.course.lesson}}</td><td class="py-4 px-6">{{i.course.professor}}</td><td class="py-4 px-6">{{i.course.lessonType}}</td><td class="py-4 px-6">{{i.date}}</td><td class="py-4 px-6">{{i.course.startingHour}}</td><td class="py-4 px-6">{{i.course.endingHour}}</td><td class="py-4 px-6">{{i.course.amphitheater.name}}</td><td class="py-4 px-6">{{i.course.amphitheater.capacity}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-3"></div>
+      <div class="col-md-6 p-0 pt-3">
+        <h2 style="text-align: center;">Εισάγετε τον αριθμό της θέσης σας</h2><br>
+        {% for i in selected_lecture %}
+        <form class="login-form" action="/lectures/{{i.id}}/add" method="POST">
+         {% csrf_token %}
+           <div class="mb-3 bg-color">
+           <label>Αριθμός θέσης</label>
+           <input type="text" name="positionNumber" class="form-control" required>
+          </div>
+          <input type="submit" class="btn btn-custom btn-lg btn-block mt-3" value="Εισαγωγή">
+          <div class="text-center pt-3 pb-3"><h4>{{result}}</h4></div>
+        </form>
+        {% endfor %}
+      </div>
+      <div class="col-md-3"></div>
+    </div>
+  </div>
+
+  {% else %}
   <br>
   <h2 style="text-align: center;">Σημερινές Διαλέξεις</h2>
   <table style="width: 100%; margin: 40px;">
     <thead>
        <tr>
-         <th>Μάθημα</th>
-         <th>Καθηγητής</th>
-         <th>Τύπος μαθήματος</th>
-         <th>Ημερομηνία</th>
-         <th>Ωρα έναρξης</th>
-         <th>Ωρα λήξης</th>
-         <th>Αίθουσα</th>
-         <th>Χώρητικότητα Αίθουσας</th>
-         <!--
-         <th>Οροφος</th>
-         -->
+         <th>Μάθημα</th><th>Καθηγητής</th><th>Τύπος μαθήματος</th><th>Ημερομηνία</th><th>Ωρα έναρξης</th><th>Ωρα λήξης</th><th>Αίθουσα</th><th>Χώρητικότητα Αίθουσας</th>
        </tr>
     </thead>
     <tbody>
       {% for i in lecture %}
        <tr class="even:bg-gray-50">
-         <td class="py-4 px-6"><a href="/lectures/{{i.id}}/">{{i.course.lesson}}</a></td>
-         <td class="py-4 px-6">{{i.course.professor}}</td>
-         <td class="py-4 px-6">{{i.course.lessonType}}</td>
-         <td class="py-4 px-6">{{i.date}}</td>
-         <td class="py-4 px-6">{{i.course.startingHour}}</td>
-         <td class="py-4 px-6">{{i.course.endingHour}}</td>
-         <td class="py-4 px-6">{{i.course.amphitheater.name}}</td>
-         <td class="py-4 px-6">{{i.course.amphitheater.capacity}}</td>
-         <!--
-         <td class="py-4 px-6">{{i.course.amphitheater.floor}}</td>
-         -->
+         <td class="py-4 px-6"><a href="/lectures/{{i.id}}/">{{i.course.lesson}}</a></td><td class="py-4 px-6">{{i.course.professor}}</td><td class="py-4 px-6">{{i.course.lessonType}}</td><td class="py-4 px-6">{{i.date}}</td><td class="py-4 px-6">{{i.course.startingHour}}</td><td class="py-4 px-6">{{i.course.endingHour}}</td><td class="py-4 px-6">{{i.course.amphitheater.name}}</td><td class="py-4 px-6">{{i.course.amphitheater.capacity}}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce duplication by rendering all authenticated UI (home, show, lecture, covid) from a single template instead of several separate templates.
- Simplify data passing by loading common context (today's lectures and the current user's positions) in the view layer for all authenticated screens.
- Make it easier to maintain shared navigation and forms by consolidating conditional sections into one file.

### Description
- Updated view handlers to render `templates/index.html` with a `view` context flag (`home`, `show`, `lecture`, `covid`) and to supply shared context (`lecture`, `position`, `user`).
- Merged per-screen templates into a single `templates/index.html` containing conditional blocks that show the appropriate section based on `view`.
- Preserved existing routes and form endpoints (for example `/covidAdd` and `/lectures/<id>/add`) while adapting handlers to return the unified page, and added `_render_lecture_with_message` helper to re-render the lecture view with error messages.
- Minor code cleanup and formatting changes in `covidtracker/views.py` to support the refactor.

### Testing
- Ran `python manage.py check` which failed because the `django` package is not installed in this environment, so framework-level checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b9f4f47883278d14eda8912f2083)